### PR TITLE
Make client exit graceful

### DIFF
--- a/client.py
+++ b/client.py
@@ -62,8 +62,8 @@ def main() -> None:
             send_q.put(None)
             try:
                 call.cancel()
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"Failed to cancel the call: {e}")
             recv_thread.join(timeout=2)
             if recv_thread.is_alive():
                 print("Warning: recv_thread did not terminate within the timeout.")

--- a/client.py
+++ b/client.py
@@ -54,6 +54,8 @@ def main() -> None:
                     if text == "/quit":
                         break
                     send_q.put(text)
+        except KeyboardInterrupt:
+            print("KeyboardInterrupt received, exiting...")
         except Exception as e:
             print(f"unanticipated exception: {e}")
         finally:

--- a/client.py
+++ b/client.py
@@ -52,8 +52,6 @@ def main() -> None:
                 while True:
                     text = session.prompt("", multiline=False)
                     if text == "/quit":
-                        send_q.put(None)
-                        call.cancel()
                         break
                     send_q.put(text)
         finally:

--- a/client.py
+++ b/client.py
@@ -65,6 +65,8 @@ def main() -> None:
             except Exception:
                 pass
             recv_thread.join(timeout=2)
+            if recv_thread.is_alive():
+                print("Warning: recv_thread did not terminate within the timeout.")
 
     print("Disconnected")
 

--- a/client.py
+++ b/client.py
@@ -52,10 +52,16 @@ def main() -> None:
                 while True:
                     text = session.prompt("", multiline=False)
                     if text == "/quit":
+                        send_q.put(None)
+                        call.cancel()
                         break
                     send_q.put(text)
         finally:
             send_q.put(None)
+            try:
+                call.cancel()
+            except Exception:
+                pass
             recv_thread.join()
 
     print("Disconnected")

--- a/client.py
+++ b/client.py
@@ -54,6 +54,8 @@ def main() -> None:
                     if text == "/quit":
                         break
                     send_q.put(text)
+        except Exception as e:
+            print(f"unanticipated exception: {e}")
         finally:
             send_q.put(None)
             try:

--- a/client.py
+++ b/client.py
@@ -64,7 +64,7 @@ def main() -> None:
                 call.cancel()
             except Exception:
                 pass
-            recv_thread.join()
+            recv_thread.join(timeout=2)
 
     print("Disconnected")
 


### PR DESCRIPTION
## Summary

- Send sentinel to `_request_generator` to finish and cancel the stream when client breaks and on any exception
    - Exception handling can be made more sophisticated later.

## Testing

- Running locally (see screencap)
![image](https://github.com/user-attachments/assets/99d0b74a-1bf8-4460-b23b-32d0addbedd1)

