### PR TITLE
Handle missing server gracefully

### DIFF
--- a/client.py
+++ b/client.py
@@ -42,6 +42,14 @@ def main() -> None:
     session = PromptSession()
 
     with grpc.insecure_channel("localhost:50051") as channel:
+        try:
+            grpc.channel_ready_future(channel).result(timeout=2)
+        except grpc.FutureTimeoutError:
+            print(
+                "Error: could not connect to chat server on localhost:50051."
+            )
+            return
+
         stub = chat_pb2_grpc.ChatServiceStub(channel)
         call = stub.ChatStream(_request_generator(username, send_q))
 

--- a/client.py
+++ b/client.py
@@ -48,7 +48,7 @@ def main() -> None:
             print(
                 "Error: could not connect to chat server on localhost:50051."
             )
-            return
+            sys.exit(1)
 
         stub = chat_pb2_grpc.ChatServiceStub(channel)
         call = stub.ChatStream(_request_generator(username, send_q))


### PR DESCRIPTION
## Summary
- check channel readiness before joining chat stream
- exit the client if the server is unreachable

## Testing
- `python -m py_compile client.py`
- `python client.py <<'EOF'
John
/quit
EOF` *(fails: No module named 'grpc')*

------
https://chatgpt.com/codex/tasks/task_e_685239cdda288325873250855adbad00